### PR TITLE
Node status on issue udpates

### DIFF
--- a/adc.html
+++ b/adc.html
@@ -11,7 +11,7 @@
         outputs: 1,
         icon: 'file.png',
         label: function () {
-            return (this.name || 'adc');
+            return (this.name || 'ADC' + this.channel);
         }
     });
 </script>

--- a/adc.js
+++ b/adc.js
@@ -23,6 +23,10 @@ module.exports = function (RED) {
 
                 node.plate.update_status();
             }else if (node.plate.plate_status == 2) {
+                node.status({fill: "red", shape: "ring", text: "missing python dependencies"});
+                node.log("missing python dependencies");
+            }else if (node.plate.plate_status == 3) {
+                node.status({fill: "red", shape: "ring", text: "python process error"});
                 node.log("python process error");
             }else if (!channelValid) {
                 node.status({fill: "red", shape: "ring", text: "invalid channel"});

--- a/dac.html
+++ b/dac.html
@@ -11,7 +11,7 @@
         outputs: 1,
         icon: 'file.png',
         label: function () {
-            return (this.name || 'dac');
+            return (this.name || 'DAC' + this.channel);
         }
     });
 </script>

--- a/dac.js
+++ b/dac.js
@@ -15,7 +15,7 @@ module.exports = function (RED) {
                 const obj = {cmd: "setDAC", args: {channel: node.channel, value: msg.payload}};
                 node.plate.send(obj, (reply) => {
                     node.value = reply.value;
-                    //node.status({text: node.value});
+                    node.status({text: node.value});
                     node.send({payload: node.value});
                 });
             }else if (node.plate.plate_status == 1) {
@@ -24,11 +24,16 @@ module.exports = function (RED) {
 
                 node.plate.update_status();
             }else if (node.plate.plate_status == 2) {
+                node.status({fill: "red", shape: "ring", text: "missing python dependencies"});
+                node.log("missing python dependencies");
+            }else if (node.plate.plate_status == 3) {
+                node.status({fill: "red", shape: "ring", text: "python process error"});
                 node.log("python process error");
             }else if (!channelValid) {
                 node.status({fill: "red", shape: "ring", text: "invalid channel"});
                 node.log("invalid channel");
             }else if (!inputValid) {
+                node.status({fill: "red", shape: "ring", text: "invalid DAC value: ignoring"});
                 node.log("invalid DAC value: ignoring");
             }
         });

--- a/din.html
+++ b/din.html
@@ -11,7 +11,7 @@
         outputs: 1,
         icon: 'file.png',
         label: function () {
-            return (this.name || 'din');
+            return (this.name || 'DIN' + this.input);
         }
     });
 </script>

--- a/din.js
+++ b/din.js
@@ -28,6 +28,10 @@ module.exports = function (RED) {
 
                 node.plate.update_status();
             }else if (node.plate.plate_status == 2) {
+                node.status({fill: "red", shape: "ring", text: "missing python dependencies"});
+                node.log("missing python dependencies");
+            }else if (node.plate.plate_status == 3) {
+                node.status({fill: "red", shape: "ring", text: "python process error"});
                 node.log("python process error");
             }else if (!channelValid) {
                 node.status({fill: "red", shape: "ring", text: "invalid channel"});

--- a/dout.html
+++ b/dout.html
@@ -11,7 +11,7 @@
         outputs: 1,
         icon: 'file.png',
         label: function () {
-            return (this.name || 'dout');
+            return (this.name || 'DOUT' + this.output);
         }
     });
 </script>

--- a/dout.js
+++ b/dout.js
@@ -37,11 +37,16 @@ module.exports = function (RED) {
 
                 node.plate.update_status();
             }else if (node.plate.plate_status == 2) {
+                node.status({fill: "red", shape: "ring", text: "missing python dependencies"});
+                node.log("missing python dependencies");
+            }else if (node.plate.plate_status == 3) {
+                node.status({fill: "red", shape: "ring", text: "python process error"});
                 node.log("python process error");
             }else if (!channelValid) {
                 node.status({fill: "red", shape: "ring", text: "invalid channel"});
                 node.log("invalid channel");
             }else if (!inputValid) {
+                node.status({fill: "red", shape: "ring", text: "invalid input"});
                 node.log("invalid input");
             }
         });

--- a/freq.html
+++ b/freq.html
@@ -10,7 +10,7 @@
         outputs: 1,
         icon: 'file.png',
         label: function () {
-            return (this.name || 'freq');
+            return (this.name || 'FREQ');
         }
     });
 </script>

--- a/freq.js
+++ b/freq.js
@@ -23,6 +23,10 @@ module.exports = function (RED) {
 
                 node.plate.update_status();
             }else if (node.plate.plate_status == 2) {
+                node.status({fill: "red", shape: "ring", text: "missing python dependencies"});
+                node.log("missing python dependencies");
+            }else if (node.plate.plate_status == 3) {
+                node.status({fill: "red", shape: "ring", text: "python process error"});
                 node.log("python process error");
             }else if (!channelValid) {
                 node.status({fill: "red", shape: "ring", text: "invalid channel"});

--- a/led.html
+++ b/led.html
@@ -11,7 +11,7 @@
         outputs: 1,
         icon: 'file.png',
         label: function () {
-            return (this.name || 'led');
+            return (this.name || 'LED');
         }
     });
 </script>

--- a/led.js
+++ b/led.js
@@ -31,12 +31,17 @@ module.exports = function (RED) {
 
                 node.plate.update_status();
             }else if (node.plate.plate_status == 2) {
+                node.status({fill: "red", shape: "ring", text: "missing python dependencies"});
+                node.log("missing python dependencies");
+            }else if (node.plate.plate_status == 3) {
+                node.status({fill: "red", shape: "ring", text: "python process error"});
                 node.log("python process error");
             }else if (!channelValid) {
                 node.status({fill: "red", shape: "ring", text: "invalid plate type"});
                 node.log("invalid plate type");
             }else if (!inputValid) {
-                node.log("invalid input type");
+                node.status({fill: "red", shape: "ring", text: "invalid input"});
+                node.log("invalid input");
             }
         });
 

--- a/relay.html
+++ b/relay.html
@@ -11,7 +11,7 @@
         outputs: 1,
         icon: 'file.png',
         label: function () {
-            return (this.name || 'relay');
+            return (this.name || 'RELAY' + this.relay);
         }
     });
 </script>

--- a/relay.js
+++ b/relay.js
@@ -35,11 +35,16 @@ module.exports = function (RED) {
 
                 node.plate.update_status();
             }else if (node.plate.plate_status == 2) {
+                node.status({fill: "red", shape: "ring", text: "missing python dependencies"});
+                node.log("missing python dependencies");
+            }else if (node.plate.plate_status == 3) {
+                node.status({fill: "red", shape: "ring", text: "python process error"});
                 node.log("python process error");
             }else if (!relayValid) {
                 node.status({fill: "red", shape: "ring", text: "invalid relay"});
                 node.log("invalid relay");
             }else if (!inputValid) {
+                node.status({fill: "red", shape: "ring", text: "invalid input"});
                 node.log("invalid input");
             }
         });

--- a/temp.html
+++ b/temp.html
@@ -12,7 +12,7 @@
         outputs: 1,
         icon: 'file.png',
         label: function () {
-            return (this.name || 'temp');
+            return (this.name || 'TEMP' + this.input);
         }
     });
 </script>

--- a/temp.js
+++ b/temp.js
@@ -29,6 +29,10 @@ module.exports = function (RED) {
 
                 node.plate.update_status();
             }else if (node.plate.plate_status == 2) {
+                node.status({fill: "red", shape: "ring", text: "missing python dependencies"});
+                node.log("missing python dependencies");
+            }else if (node.plate.plate_status == 3) {
+                node.status({fill: "red", shape: "ring", text: "python process error"});
                 node.log("python process error");
             }else if (!channelValid) {
                 node.status({fill: "red", shape: "ring", text: "invalid channel"});

--- a/thermo.html
+++ b/thermo.html
@@ -11,7 +11,7 @@
         outputs: 1,
         icon: 'file.png',
         label: function () {
-            return (this.name || 'temp');
+            return (this.name || 'TEMP' + this.channel);
         }
     });
 </script>

--- a/thermo.js
+++ b/thermo.js
@@ -24,6 +24,10 @@ module.exports = function (RED) {
 
                 node.plate.update_status();
             }else if (node.plate.plate_status == 2) {
+                node.status({fill: "red", shape: "ring", text: "missing python dependencies"});
+                node.log("missing python dependencies");
+            }else if (node.plate.plate_status == 3) {
+                node.status({fill: "red", shape: "ring", text: "python process error"});
                 node.log("python process error");
             }else if (!channelValid){
                 node.status({fill: "red", shape: "ring", text: "invalid plate type"});


### PR DESCRIPTION
Changes the node status for any issue. For example, if the issue was related to the underlying python process, it would log the error in node red, but it wouldn't update the user, so the user wouldn't know what was wrong. Additionally, breaks apart python issues into "missing python dependencies" if pi-plates or pygame is missing and "python process error" if it crashes for another reason.