### PR TITLE
Fix DOUT channel 7 on DAQC2plate

### DIFF
--- a/dout.js
+++ b/dout.js
@@ -12,7 +12,9 @@ module.exports = function (RED) {
         var node = this;
         node.on('input', function (msg) {
             let type = RED.nodes.getNode(config.config_plate).model;
-            let channelValid = (type == "DAQCplate" || type == "DAQC2plate") && node.output < 7 || type == "TINKERplate" && node.output > 0;
+            let channelValid = type == "DAQCplate" && node.output < 7 ||
+			type == "DAQC2plate" && node.output < 8 ||
+			type == "TINKERplate" && node.output > 0;
 
             let validInputs = ["on", "off", "toggle"];
             let inputValid = (typeof msg.payload === 'string' && validInputs.includes(msg.payload));


### PR DESCRIPTION
Channel valid test was assuming same digital out channel limit for DAQCplate (has 7) and DAQC2plate (has 8).  Refactored channel valid test to support both boards separately.