### PR TITLE
Fixed TINKERplate DIN error

### DIFF
--- a/din.js
+++ b/din.js
@@ -5,12 +5,13 @@ module.exports = function (RED) {
         this.input = parseInt(config.input, 10);
         this.state = 0;
 
+        var node = this;
+
         if (RED.nodes.getNode(config.config_plate).model  == "TINKERplate"){
             const conf = {cmd: "setIN", args: {bit: node.input}};
             node.plate.send(conf, (reply) => {});
         }
 
-        var node = this;
         node.on('input', function (msg) {
             let type = RED.nodes.getNode(config.config_plate).model;
             let channelValid = ((type == "DAQCplate" || type == "DAQC2plate") && node.input < 8) || type == "TINKERplate" && node.input > 0;


### PR DESCRIPTION
Accidentally used the node variable before it was defined. Didn't notice before, because the usage only applied when the plate in question was a TINKERplate.