### PR TITLE
changed node colors and  names, and selected more descriptive icons

### DIFF
--- a/adc.html
+++ b/adc.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     RED.nodes.registerType('ppADC', {
         category: 'Pi_Plates',
-        color: '#a6bbcf',
+        color: '#87A980',
         defaults: {
             config_plate: { value: '', type: "pi_plate"},
             name: { value: ''},
@@ -9,9 +9,10 @@
         },
         inputs: 1,
         outputs: 1,
-        icon: 'file.png',
+        icon: 'analog.svg',
+	paletteLabel: 'ADC',
         label: function () {
-            return (this.name || 'ADC' + this.channel);
+            return (this.name || 'ADC' + this.channel);	
         }
     });
 </script>

--- a/alladc.html
+++ b/alladc.html
@@ -1,14 +1,15 @@
 <script type="text/javascript">
     RED.nodes.registerType('ppAllADC', {
         category: 'Pi_Plates',
-        color: '#a6bbcf',
+        color: '#87A980',
         defaults: {
             config_plate: { value: '', type: "pi_plate"},
             name: { value: ''}
         },
         inputs: 1,
         outputs: 8,
-        icon: 'file.png',
+        icon: 'analog.png',
+	paletteLabel: 'allADC',
         label: function () {
             return (this.name || 'ADC');
         }

--- a/dac.html
+++ b/dac.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     RED.nodes.registerType('ppDAC', {
         category: 'Pi_Plates',
-        color: '#a6bbcf',
+        color: '#87A980',
         defaults: {
             config_plate: { value: '', type: "pi_plate"},
             name: { value: ''},
@@ -9,7 +9,9 @@
         },
         inputs: 1,
         outputs: 1,
-        icon: 'file.png',
+        align: 'right',
+        icon: 'analog.png',
+        paletteLabel: 'DAC',
         label: function () {
             return (this.name || 'DAC' + this.channel);
         }

--- a/din.html
+++ b/din.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     RED.nodes.registerType('ppDIN', {
         category: 'Pi_Plates',
-        color: '#a6bbcf',
+        color: '#87A980',
         defaults: {
             config_plate: { value: '', type: "pi_plate"},
             name: { value: ''},
@@ -9,7 +9,8 @@
         },
         inputs: 1,
         outputs: 1,
-        icon: 'file.png',
+        icon: 'serial.svg',
+	paletteLabel: 'DIN',
         label: function () {
             return (this.name || 'DIN' + this.input);
         }

--- a/dout.html
+++ b/dout.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     RED.nodes.registerType('ppDOUT', {
         category: 'Pi_Plates',
-        color: '#a6bbcf',
+        color: '#87A980',
         defaults: {
             config_plate: { value: '', type: "pi_plate"},
             name: { value: ''},
@@ -9,7 +9,9 @@
         },
         inputs: 1,
         outputs: 1,
-        icon: 'file.png',
+	align:'right',
+        icon: 'serial.svg',
+	paletteLabel: 'DOUT',
         label: function () {
             return (this.name || 'DOUT' + this.output);
         }

--- a/freq.html
+++ b/freq.html
@@ -1,14 +1,15 @@
 <script type="text/javascript">
     RED.nodes.registerType('ppFREQ', {
         category: 'Pi_Plates',
-        color: '#a6bbcf',
+        color: '#87A980',
         defaults: {
             config_plate: { value: '', type: "pi_plate"},
             name: { value: ''}
         },
         inputs: 1,
         outputs: 1,
-        icon: 'file.png',
+        icon: 'serial.png',
+	paletteLabel: 'FREQ',
         label: function () {
             return (this.name || 'FREQ');
         }

--- a/icons/analog.svg
+++ b/icons/analog.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="40px" height="60px" viewBox="0 0 40 60" enable-background="new 0 0 40 60" xml:space="preserve">
+<path fill="none" stroke="#FFFFFF" stroke-width="5" stroke-linecap="square" d="M4.5,30.5c0,0,4.667-17.995,8.04-17.995
+	c5.001,0,9.501,34.995,15.96,34.995c4.505,0,7-17,7-17"/>
+<path fill="none" stroke="#FFFFFF" stroke-width="5" stroke-linecap="square" d="M8.5,47.5"/>
+</svg>

--- a/icons/relay.svg
+++ b/icons/relay.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="40px" height="60px" viewBox="0 0 40 60" enable-background="new 0 0 40 60" xml:space="preserve">
+<path fill="none" stroke="#FFFFFF" stroke-width="5" stroke-linecap="square" d="M28.5,30.5h7"/>
+<path fill="none" stroke="#FFFFFF" stroke-width="5" stroke-linecap="square" d="M4.5,30.5l8.04,0.005L28.5,17.5"/>
+<path fill="none" stroke="#FFFFFF" stroke-width="5" stroke-linecap="square" d="M8.5,47.5"/>
+</svg>

--- a/led.html
+++ b/led.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     RED.nodes.registerType('ppLED', {
         category: 'Pi_Plates',
-        color: '#a6bbcf',
+        color: '#87A980',
         defaults: {
             config_plate: { value: '', type: "pi_plate"},
             name: { value: ''},
@@ -9,7 +9,9 @@
         },
         inputs: 1,
         outputs: 1,
-        icon: 'file.png',
+	align:'right',
+        icon: 'light.svg',
+	paletteLabel: 'LED',
         label: function () {
             return (this.name || 'LED');
         }

--- a/relay.html
+++ b/relay.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     RED.nodes.registerType('ppRelay', {
         category: 'Pi_Plates',
-        color: '#a6bbcf',
+        color: '#87A980',
         defaults: {
             config_plate: { value: '', type: "pi_plate"},
             name: { value: ''},
@@ -9,7 +9,9 @@
         },
         inputs: 1,
         outputs: 1,
-        icon: 'file.png',
+	align:'right',
+        icon: 'relay.svg',
+	paletteLabel: 'RELAY',
         label: function () {
             return (this.name || 'RELAY' + this.relay);
         }

--- a/temp.html
+++ b/temp.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     RED.nodes.registerType('ppTEMP', {
         category: 'Pi_Plates',
-        color: '#a6bbcf',
+        color: '#87A980',
         defaults: {
             config_plate: { value: '', type: "pi_plate"},
             name: { value: ''},
@@ -10,7 +10,8 @@
         },
         inputs: 1,
         outputs: 1,
-        icon: 'file.png',
+        icon: "font-awesome/fa-thermometer",
+	paletteLabel: 'DS18B20',
         label: function () {
             return (this.name || 'TEMP' + this.input);
         }

--- a/thermo.html
+++ b/thermo.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     RED.nodes.registerType('ppTHERMO', {
         category: 'Pi_Plates',
-        color: '#a6bbcf',
+        color: '#87A980',
         defaults: {
             config_plate: { value: '', type: "pi_plate"},
             name: { value: ''},
@@ -9,7 +9,8 @@
         },
         inputs: 1,
         outputs: 1,
-        icon: 'file.png',
+        icon: "font-awesome/fa-thermometer",
+	paletteLabel: 'THERMO',
         label: function () {
             return (this.name || 'TEMP' + this.channel);
         }


### PR DESCRIPTION
See updated node palette in image below. 
1) node colors were changed from #a6bbcf to #87A980
2) more intuitive icons were selected and/or created
3) for output nodes (RELAY, DOUT, LED, and DAC), the icons were right-justified
4) node labels were simplified and/or made specific using the Palette Label property. This approach was taken to avoid breaking existing flows.

![Screenshot 2021-09-20 124213](https://user-images.githubusercontent.com/8397057/134040903-a4e212db-9618-4210-acf0-1a78ebcb54a8.jpg)

