### PR TITLE
RELAY2plate Support and New PWM node

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A <a href="http://nodered.org" target="_new">Node-RED</a> node that enables
 communication with <a href="https://pi-plates.com">Pi-Plates</a> boards.
 
  - RELAYplate
+ - RELAYplate2
  - DAQCplate
- - MOTORplate
+ - DAQC2plate
  - TINKERplate
 
 Install

--- a/node_modules/pi-plates/BASEplate.js
+++ b/node_modules/pi-plates/BASEplate.js
@@ -1,0 +1,97 @@
+const vasync = require('vasync');
+const readline = require('readline');
+const { spawn } = require('child_process');
+const assert = require('assert');
+
+let child = spawn('python3', ['-u', __dirname + '/plate_io.py']);
+
+let child_status = 0;
+
+child.on('error', (err) => {
+    console.log('child error: ' + err);
+});
+
+child.on('exit', (code, signal) => {
+    console.log(`code: ${code} signal: ${signal}`);
+    child_status = code;
+});
+
+child.stderr.on('data', (data) => {
+    console.log('stderr: ' + data);
+});
+
+const rl = readline.createInterface({
+    input: child.stdout
+});
+
+function do_cmd(task, cb) {
+    if (!child_status){
+        const cmd_str = JSON.stringify(task) + '\n';
+        child.stdin.write(cmd_str);
+        assert.equal(rl.listenerCount('line'), 0);
+        rl.once('line', (line) => {
+            const reply = JSON.parse(line);
+            cb(reply);
+        });
+    }
+}
+
+const queue = vasync.queue(do_cmd, 1);
+
+class BASEplate {
+    constructor (addr, plate_type) {
+        this.addr = addr;
+        this.plate_type = plate_type;
+        this.queue = queue;
+
+        /* plate_status stores information about whether or not this plate can currently
+         * be used, or if there is an issue:
+         * 0 = no error
+         * 1 = plate not found
+         * 2 = missing python dependencies
+         * 3 = unknown python error
+         * 4 = unknown state
+         */
+        this.plate_status = 4;
+
+        this.update_status();
+    }
+
+    // Updates this.plate_status.
+    update_status () {
+        if (child_status) {
+            this.plate_status = child_status;
+        }else {
+            const verifier = {cmd: "VERIFY", args: {}};
+
+            this.send(verifier, (reply) => {
+                // If the plate was invalid and now works, the piplates library
+                // needs that update as well. So, we activate the piplate:
+
+                if (this.plate_status == 1 && !reply.state) {
+                    const update = {cmd: "ACTIVATE", args: {}};
+
+                    this.send(update, (reply) => {});
+                }
+
+                this.plate_status = reply.state;
+            });
+        }
+    }
+    send (obj, receive_cb) {
+        // send a request to this plate using the form:
+        // {cmd: <pi-plate command>, args: {<command-specific args>}
+        // e.g. {cmd: "relayTOGGLE", args: { relay: 4}}
+
+        obj['plate_type'] = this.plate_type;
+        obj['addr'] = this.addr;
+
+        if (!child_status)
+            this.queue.push(obj, receive_cb);
+    }
+    shutdown () {
+        child.kill();
+    }
+}
+
+module.exports = BASEplate;

--- a/node_modules/pi-plates/DAQC2plate.js
+++ b/node_modules/pi-plates/DAQC2plate.js
@@ -1,0 +1,9 @@
+const BASEplate = require('./BASEplate');
+
+class DAQC2plate extends BASEplate {
+    constructor (addr) {
+        super(addr, "DAQC2");
+    }
+}
+
+module.exports = DAQC2plate;

--- a/node_modules/pi-plates/DAQCplate.js
+++ b/node_modules/pi-plates/DAQCplate.js
@@ -1,0 +1,9 @@
+const BASEplate = require('./BASEplate');
+
+class DAQCplate extends BASEplate {
+    constructor (addr) {
+        super(addr, "DAQC");
+    }
+}
+
+module.exports = DAQCplate;

--- a/node_modules/pi-plates/MOTORplate.js
+++ b/node_modules/pi-plates/MOTORplate.js
@@ -1,0 +1,9 @@
+const BASEplate = require('./BASEplate');
+
+class MOTORplate extends BASEplate {
+    constructor (addr) {
+        super(addr, "MOTOR");
+    }
+}
+
+module.exports = MOTORplate;

--- a/node_modules/pi-plates/README.md
+++ b/node_modules/pi-plates/README.md
@@ -1,0 +1,2 @@
+control Pi-Plates from node
+***requires python 3.x via 'python3' command***

--- a/node_modules/pi-plates/RELAYplate.js
+++ b/node_modules/pi-plates/RELAYplate.js
@@ -1,0 +1,9 @@
+const BASEplate = require('./BASEplate');
+
+class RELAYplate extends BASEplate {
+    constructor (addr) {
+        super(addr, "RELAY");
+    }
+}
+
+module.exports = RELAYplate;

--- a/node_modules/pi-plates/RELAYplate2.js
+++ b/node_modules/pi-plates/RELAYplate2.js
@@ -1,0 +1,9 @@
+const BASEplate = require('./BASEplate');
+
+class RELAYplate2 extends BASEplate {
+    constructor (addr) {
+        super(addr, "RELAY2");
+    }
+}
+
+module.exports = RELAYplate2;

--- a/node_modules/pi-plates/THERMOplate.js
+++ b/node_modules/pi-plates/THERMOplate.js
@@ -1,0 +1,9 @@
+const BASEplate = require('./BASEplate');
+
+class THERMOplate extends BASEplate {
+    constructor (addr) {
+        super(addr, "THERMO");
+    }
+}
+
+module.exports = THERMOplate;

--- a/node_modules/pi-plates/TINKERplate.js
+++ b/node_modules/pi-plates/TINKERplate.js
@@ -1,0 +1,9 @@
+const BASEplate = require('./BASEplate');
+
+class TINKERplate extends BASEplate {
+	constructor (addr) {
+		super(addr, "TINKER");
+	}
+}
+
+module.exports = TINKERplate;

--- a/node_modules/pi-plates/package.json
+++ b/node_modules/pi-plates/package.json
@@ -1,0 +1,70 @@
+{
+  "_from": "pi-plates@>=0.1.5",
+  "_id": "pi-plates@0.1.5",
+  "_inBundle": false,
+  "_integrity": "sha512-2RP0Z9rzWas6HA6l2FhGvaW+9oj4ziSGMaRGSJRv2plbFKhiXOIxyyhY4qYjQ+4Cbuu9kPjcevqNdmUmAepRww==",
+  "_location": "/node-red-contrib-pi-plates/pi-plates",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "pi-plates@>=0.1.5",
+    "name": "pi-plates",
+    "escapedName": "pi-plates",
+    "rawSpec": ">=0.1.5",
+    "saveSpec": null,
+    "fetchSpec": ">=0.1.5"
+  },
+  "_requiredBy": [
+    "/node-red-contrib-pi-plates"
+  ],
+  "_resolved": "https://registry.npmjs.org/pi-plates/-/pi-plates-0.1.5.tgz",
+  "_shasum": "e5d70d813dbb117b22ea971dde73050b41cdf3aa",
+  "_spec": "pi-plates@>=0.1.5",
+  "_where": "/home/pi/node-red-contrib-pi-plates",
+  "author": {
+    "name": "Mike Harsch",
+    "email": "mike@harschsystems.com"
+  },
+  "bugs": {
+    "url": "https://github.com/Harsch-Systems/node-pi-plates/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "vasync": "2.x.x"
+  },
+  "deprecated": false,
+  "description": "control Pi-Plates from node",
+  "devDependencies": {},
+  "directories": {
+    "test": "tests"
+  },
+  "homepage": "https://github.com/Harsch-Systems/node-pi-plates#readme",
+  "keywords": [
+    "adc",
+    "dac",
+    "relay",
+    "RELAYplate",
+    "DAQCplate",
+    "DAQC2plate",
+    "MOTORplate",
+    "THERMOplate",
+    "TINKERplate",
+    "thermocouple",
+    "ds18b20",
+    "Pi-Plates",
+    "pi",
+    "plates"
+  ],
+  "license": "Apache-2.0",
+  "main": "plates.js",
+  "name": "pi-plates",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Harsch-Systems/node-pi-plates.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "version": "0.1.5"
+}

--- a/node_modules/pi-plates/plate_io.py
+++ b/node_modules/pi-plates/plate_io.py
@@ -1,0 +1,302 @@
+import sys
+import json
+
+# All Pi Plate communication must go through this one process to ensure
+# SPI communications don't overlap / interfere and corrupt the device state(s)
+#
+# listen for json messages on stdin of the format:
+# {
+#   addr: <pi plate address 0-7>,
+#   plate_type: <RELAY|DAQC>,
+#   cmd: <command string>, args: {<command-specific args>}
+# }
+
+while True:
+    try:
+        line = sys.stdin.readline()
+        # TODO: add error handling for invalid JSON
+        msg = json.loads(line)
+        addr = msg['addr']
+        plate_type = msg['plate_type']
+        cmd = msg['cmd']
+        args = msg['args']
+        resp = {}
+        if (plate_type == "RELAY" or plate_type == "RELAY2"):
+        # switch between RELAY and RELAY2 for their common API
+            if (plate_type == "RELAY2"):
+                import piplates.RELAYplate2 as RP2
+                RP = RP2
+            else:
+                import piplates.RELAYplate as RP
+                RP = RP
+            if (cmd == "setLED"):
+                RP.setLED(addr)
+                resp['state'] = 1
+            elif (cmd == "clrLED"):
+                RP.clrLED(addr)
+                resp['state'] = 0
+            elif (cmd == "toggleLED"):
+                RP.toggleLED(addr)
+                resp['state'] = "UNKNOWN"
+            elif (cmd == "getID"):
+                resp['ID'] = RP.getID(addr)
+            elif (cmd == "getHWrev"):
+                resp['HWrev'] = RP.getHWrev(addr)
+            elif (cmd == "getFWrev"):
+                resp['FWrev'] = RP.getFWrev(addr)
+            elif (cmd == "getPMrev"):
+                resp['PMrev'] = RP.getPMrev()
+            elif (cmd == "getADDR"):
+                resp['ADDR'] = RP.getADDR(addr)
+            elif ("relay" in cmd):
+                relay = args['relay']
+                if (cmd == "relayON"):
+                    RP.relayON(addr, relay)
+                elif (cmd == "relayOFF"):
+                    RP.relayOFF(addr, relay)
+                elif (cmd == "relayTOGGLE"):
+                    RP.relayTOGGLE(addr, relay)
+                state = RP.relaySTATE(addr)
+                this_state = (state >> (relay - 1)) & 1
+                resp['relay'] = relay
+                resp['state'] = this_state
+            elif (cmd == "RESET"):
+                RP.RESET(addr)
+                resp['RESET'] = "OK";
+            elif (cmd == "VERIFY"):
+                if(RP.getADDR(addr) == addr):
+                    resp['state'] = 0
+                else:
+                    resp['state'] = 1
+            elif (cmd == "ACTIVATE"):
+                RP.relaysPresent[addr] = 1
+                resp['state'] = 1
+            else:
+                sys.stderr.write("unknown relay cmd: " + cmd)
+                break
+            print(json.dumps(resp))
+        elif (plate_type == "DAQC" or plate_type == "DAQC2"):
+            # switch between DAQC and DAQC2 for their common API
+            if (plate_type == "DAQC2"):
+                import piplates.DAQC2plate as DP2
+                PP = DP2
+            else:
+                import piplates.DAQCplate as DP
+                PP = DP
+            if (cmd == "getDINbit"):
+                bit = args['bit']
+                state = PP.getDINbit(addr, bit)
+                resp['bit'] = bit
+                resp['state'] = state
+            elif (cmd == "setDOUTbit"):
+                bit = args['bit']
+                PP.setDOUTbit(addr, bit)
+                resp['bit'] = bit
+                resp['state'] = 1
+            elif (cmd == "clrDOUTbit"):
+                bit = args['bit']
+                PP.clrDOUTbit(addr, bit)
+                resp['bit'] = bit
+                resp['state'] = 0
+            elif (cmd == "toggleDOUTbit"):
+                bit = args['bit']
+                PP.toggleDOUTbit(addr, bit)
+                resp['bit'] = bit
+                resp['state'] = 'UNKNOWN'
+            elif (cmd == "getADC"):
+                channel = args['channel']
+                voltage = PP.getADC(addr, channel)
+                resp['channel'] = channel
+                resp['voltage'] = voltage
+            elif (cmd == "getADCall"):
+                voltages = PP.getADCall(addr)
+                resp['voltages'] = voltages
+            elif (cmd == "getTEMP" and plate_type == "DAQC"):
+                bit = args['bit']
+                scale = args['scale']
+                temp = PP.getTEMP(addr, bit, scale)
+                resp['temp'] = temp
+                resp['bit'] = bit
+            elif (cmd == "getDAC"):
+                channel = args['channel']
+                value = PP.getDAC(addr, channel)
+                resp['channel'] = channel
+                resp['value'] = value
+            elif (cmd == "setDAC"):
+                channel = args['channel']
+                value = args['value']
+                PP.setDAC(addr, channel, value)
+                resp['channel'] = channel
+                resp['value'] = value
+            elif (cmd == "getPWM"):
+                channel = args['channel']
+                value = PP.getPWM(addr, channel)
+                resp['channel'] = channel
+                resp['value'] = value
+            elif (cmd == "setPWM"):
+                channel = args['channel']
+                value = args['value']
+                PP.setPWM(addr, channel, value)
+                resp['channel'] = channel
+                resp['value'] = value
+            elif (cmd == "calDAC"):
+                PP.calDAC(addr)
+            elif (cmd == "getFREQ" and plate_type == "DAQC2"):
+                value = DP2.getFREQ(addr)
+                resp['value'] = value
+            elif (cmd == "setLED" and plate_type == "DAQC"):
+                color = args['color']
+
+                if color == 'off':
+                    DP.clrLED(addr, 0)
+                    DP.clrLED(addr, 1)
+                elif color == 'red':
+                    DP.setLED(addr, 0)
+                    DP.clrLED(addr, 1)
+                elif color == 'green':
+                    DP.clrLED(addr, 0)
+                    DP.setLED(addr, 1)
+                elif color == 'yellow':
+                    DP.setLED(addr, 0)
+                    DP.setLED(addr, 1)
+                else:
+                    sys.stderr.write("unsupported LED color: " + color)
+
+                resp['state'] = color
+            elif (cmd == "setLED" and plate_type == "DAQC2"):
+                color = args['color']
+
+                if color in ['off','red','green','yellow','blue','magenta','cyan','white']:
+                    DP2.setLED(addr, color)
+                else:
+                    sys.stderr.write("unsupported LED color: " + color)
+
+                resp['state'] = color
+            elif (cmd == "VERIFY" and plate_type == "DAQC"):
+                #For some reason the DAQC plate's getADDR method adds 8 to the address.
+                if(DP.getADDR(addr) - 8 == addr):
+                    resp['state'] = 0
+                else:
+                    resp['state'] = 1
+            elif (cmd == "VERIFY" and plate_type == "DAQC2"):
+                if(DP2.getADDR(addr) == addr):
+                    resp['state'] = 0
+                else:
+                    resp['state'] = 1
+            elif (cmd == "ACTIVATE" and plate_type == "DAQC"):
+                PP.daqcsPresent[addr] = 1
+                PP.Vcc[addr] = PP.getADC(addr, 8)
+                resp['state'] = 1
+            elif (cmd == "ACTIVATE" and plate_type == "DAQC2"):
+                PP.daqc2sPresent[addr] = 1
+                PP.getCalVals(addr)
+                resp['state'] = 1
+            else:
+                sys.stderr.write("unknown daqc(2) cmd: " + cmd)
+            print(json.dumps(resp))
+        elif (plate_type == "MOTOR"):
+            break
+        elif (plate_type == "THERMO"):
+            import piplates.THERMOplate as TP
+            if (cmd == "getTEMP"):
+                channel = args['channel']
+                value = TP.getTEMP(addr, channel)
+                resp['channel'] = channel
+                resp['value'] = value
+            elif (cmd == "getCOLD"):
+                value = TP.getCOLD(addr)
+                resp['value'] = value
+            elif (cmd == "setLED"):
+                TP.setLED(addr)
+                resp['state'] = 1
+            elif (cmd == "clrLED"):
+                TP.clrLED(addr)
+                resp['state'] = 0
+            elif (cmd == "toggleLED"):
+                TP.toggleLED(addr)
+                resp['state'] = TP.getLED(addr)
+            elif (cmd == "VERIFY"):
+                if(TP.getADDR(addr) == addr):
+                    resp['state'] = 0
+                else:
+                    resp['state'] = 1
+            elif (cmd == "ACTIVATE"):
+                TP.THERMOsPresent[addr] = 1
+                TP.getCalVals(addr)
+                resp['state'] = 1
+            else:
+                sys.stderr.write("unknown or unimplemented thermo cmd: " + cmd)
+            print(json.dumps(resp))
+        elif (plate_type == "TINKER"):
+            import piplates.TINKERplate as TINK
+            if("relay" in cmd):
+                relay = args['relay']
+                if(cmd == "relayON"):
+                    TINK.relayON(addr, relay)
+                elif (cmd == "relayOFF"):
+                    TINK.relayOFF(addr, relay)
+                elif (cmd == "relayTOGGLE"):
+                    TINK.relayTOGGLE(addr, relay)
+                state = TINK.relaySTATE(addr, relay)
+                resp['relay'] = relay
+                resp['state'] = state
+            elif("DOUT" in cmd):
+                chan = args['bit']
+                if(cmd == "setDOUTbit"):
+                    TINK.setDOUT(addr, chan)
+                    resp['state'] = 1
+                elif(cmd == "clrDOUTbit"):
+                    TINK.clrDOUT(addr, chan)
+                    resp['state'] = 0
+                elif(cmd == "toggleDOUTbit"):
+                    TINK.toggleDOUT(addr, chan)
+                    resp['state'] = 'UNKNOWN'
+                resp['bit'] = chan
+            elif(cmd == "getDINbit"):
+                chan = args['bit']
+                state = TINK.getDIN(addr, chan)
+                resp['state'] = state
+                resp['bit'] = chan
+            elif(cmd == "getADC"):
+                channel = args['channel']
+                voltage = TINK.getADC(addr, channel)
+                resp['channel'] = channel
+                resp['voltage'] = voltage
+            elif(cmd == "getTEMP"):
+                bit = args['bit']
+                scale = args['scale']
+                temp = TINK.getTEMP(addr, bit, scale)
+                resp['temp'] = temp
+                resp['bit'] = bit
+            elif (cmd == "setOUT"):
+                chan = args['bit']
+                TINK.setMODE(addr, chan, 'dout')
+                resp['state'] = "out"
+            elif (cmd == "setTEMP"):
+                chan = args['bit']
+                TINK.setMODE(addr, chan, 'temp')
+                resp['state'] = "temp"
+            elif (cmd == "setPWM"):
+                chan = args['bit']
+                TINK.setMODE(addr, chan, 'pwm')
+                resp['state'] = "pwm"                
+            elif (cmd == "setIN"):
+                chan = args['bit']
+                TINK.setMODE(addr, chan, 'din')
+                resp['state'] = "in"
+            elif (cmd == "VERIFY"):
+                if (TINK.getADDR(addr) == addr):
+                    resp['state'] = 0
+                else:
+                    resp['state'] = 1
+            elif (cmd == "ACTIVATE"):
+                TINK.platesPresent[addr] = 1
+                resp['state'] = 1
+            else:
+                sys.stderr.write("unknown or unimplemented tinker cmd: " + cmd)
+            print(json.dumps(resp))
+        else:
+            sys.stderr.write("unknown plate_type: " + plate_type)
+    except (EOFError, SystemExit, AssertionError):
+        sys.exit(3)
+

--- a/node_modules/pi-plates/plate_io.py
+++ b/node_modules/pi-plates/plate_io.py
@@ -277,6 +277,12 @@ while True:
                 TINK.setMODE(addr, chan, 'temp')
                 resp['state'] = "temp"
             elif (cmd == "setPWM"):
+                channel = args['channel']
+                value = args['value']
+                TINK.setPWM(addr, channel, value)
+                resp['channel'] = channel
+                resp['value'] = value
+            elif (cmd == "setPWMmode"):
                 chan = args['bit']
                 TINK.setMODE(addr, chan, 'pwm')
                 resp['state'] = "pwm"                

--- a/node_modules/pi-plates/plates.js
+++ b/node_modules/pi-plates/plates.js
@@ -1,0 +1,17 @@
+var RELAYplate = require('./RELAYplate');
+var RELAYplate2 = require('./RELAYplate2');
+var DAQCplate = require('./DAQCplate');
+var DAQC2plate = require('./DAQC2plate');
+var MOTORplate = require('./MOTORplate');
+var THERMOplate = require('./THERMOplate');
+var TINKERplate = require('./TINKERplate');
+
+module.exports = {
+    RELAYplate2: RELAYplate2,
+    RELAYplate: RELAYplate,
+    DAQCplate: DAQCplate,
+    DAQC2plate: DAQC2plate,
+    MOTORplate: MOTORplate,
+    THERMOplate: THERMOplate,
+    TINKERplate: TINKERplate
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
       "ppFREQ": "freq.js",
       "ppLED": "led.js",
       "ppTEMP": "temp.js",
-      "ppTHERMO": "thermo.js"
+      "ppTHERMO": "thermo.js",
+      "ppPWM": "pwm.js"
     }
   },
   "dependencies": {

--- a/plate_config.html
+++ b/plate_config.html
@@ -17,6 +17,7 @@
         <label for="node-config-input-model"><i class="icon-tag"></i> Plate Model</label>
         <select id="node-config-input-model">
             <option value="RELAYplate">RELAYplate</option>
+            <option value="RELAYplate2">RELAYplate2</option>
             <option value="DAQCplate">DAQCplate</option>
             <option value="DAQC2plate">DAQC2plate</option>
             <option value="MOTORplate">MOTORplate</option>

--- a/plate_config.js
+++ b/plate_config.js
@@ -1,4 +1,4 @@
-const { RELAYplate, DAQCplate, DAQC2plate, MOTORplate, THERMOplate, TINKERplate } = require('pi-plates');
+const { RELAYplate, RELAYplate2, DAQCplate, DAQC2plate, MOTORplate, THERMOplate, TINKERplate } = require('pi-plates');
 
 module.exports = function (RED) {
     function PlateNode(config) {
@@ -10,6 +10,9 @@ module.exports = function (RED) {
         switch (this.model) {
             case "RELAYplate":
                 this.plate = new RELAYplate(addr);
+                break;
+            case "RELAYplate2":
+                this.plate = new RELAYplate2(addr);
                 break;
             case "DAQCplate":
                 this.plate = new DAQCplate(addr);

--- a/pwm.html
+++ b/pwm.html
@@ -1,0 +1,46 @@
+<script type="text/javascript">
+    RED.nodes.registerType('ppPWM', {
+        category: 'Pi_Plates',
+        color: '#87A980',
+        defaults: {
+            config_plate: { value: '', type: "pi_plate"},
+            name: { value: ''},
+            channel: { value: "0", required: true}
+        },
+        inputs: 1,
+        outputs: 1,
+        align: 'right',
+        icon: 'serial.svg',
+        paletteLabel: 'PWM',
+        label: function () {
+            return (this.name || 'PWM' + this.channel);
+        }
+    });
+</script>
+
+<script type="text/x-red" data-template-name="ppPWM">
+    <div class="form-row">
+        <label for="node-input-config_plate"><i class="icon-tag"></i> Plate</label>
+        <input type="text" id="node-input-config_plate">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-channel"><i class="icon-tag"></i> Channel #</label>
+        <select id="node-input-channel">
+            <option value="0">0</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>  
+            <option value="6">6</option>             
+        </select>
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="ppPWM">
+    <p>PWMs accept a numeric value from 0 to 100% and set the PWM output to that duty cycle</p>
+</script>

--- a/pwm.js
+++ b/pwm.js
@@ -1,0 +1,62 @@
+module.exports = function (RED) {
+    function PWMNode(config) {
+        RED.nodes.createNode(this, config);
+        this.plate = RED.nodes.getNode(config.config_plate).plate;
+        this.channel = parseInt(config.channel, 10);
+        this.output = parseInt(config.output, 10);
+
+        //if (RED.nodes.getNode(config.config_plate).model  == "TINKERplate"){
+        //    const conf = {cmd: "setPWMmode", args: {bit: this.output}};
+        //    this.plate.send(conf, (reply) => {});
+        //}
+
+        var node = this;
+        node.on('input', function (msg) { 
+           let type = RED.nodes.getNode(config.config_plate).model;
+           let channelValid = (((type == "DAQCplate") && (node.channel < 2)) || ((type == "DAQC2plate") && (node.channel < 2)) ||
+              ((type == "TINKERplate") && (node.channel > 0)));
+           let inputValid = (typeof msg.payload === 'number' && msg.payload >= 0 && msg.payload <= 100);
+           if((type == "DAQCplate") && inputValid){msg.payload = parseInt((msg.payload * 1023.0 / 100.0)+0.5)}     
+           if (type == "TINKERplate"){
+              if (channelValid) {
+                 const conf = {cmd: "setPWMmode", args: {bit: node.channel}};
+                 node.plate.send(conf, (reply) => {});
+              }else {
+                 node.status({fill: "red", shape: "ring", text: "invalid channel"});
+                 node.log("invalid channel");
+              }
+           }        
+
+            if(!node.plate.plate_status && inputValid && channelValid){             
+                const obj = {cmd: "setPWM", args: {channel: node.channel, value: msg.payload}};
+                node.plate.send(obj, (reply) => {
+                    node.value = reply.value;
+                    node.status({text: node.value});
+                    node.send({payload: node.value});
+                });
+            }else if (node.plate.plate_status == 1) {
+                node.status({fill: "red", shape: "ring", text: "invalid plate"});
+                node.log("invalid plate");
+
+                node.plate.update_status();
+            }else if (node.plate.plate_status == 2) {
+                node.status({fill: "red", shape: "ring", text: "missing python dependencies"});
+                node.log("missing python dependencies");
+            }else if (node.plate.plate_status == 3) {
+                node.status({fill: "red", shape: "ring", text: "python process error"});
+                node.log("python process error");
+            }else if (!channelValid) {
+                node.status({fill: "red", shape: "ring", text: "invalid channel"});
+                node.log("invalid channel");
+            }else if (!inputValid) {
+                node.status({fill: "red", shape: "ring", text: "invalid PWM value: ignoring"});
+                node.log("invalid PWM value: ignoring");
+            }
+        });
+
+        this.on('close', function () {
+            // cleanup goes here
+        });
+    }
+    RED.nodes.registerType("ppPWM", PWMNode);
+}

--- a/relay.html
+++ b/relay.html
@@ -9,9 +9,9 @@
         },
         inputs: 1,
         outputs: 1,
-        align:'right',
+	align:'right',
         icon: 'relay.svg',
-        paletteLabel: 'RELAY',
+	paletteLabel: 'RELAY',
         label: function () {
             return (this.name || 'RELAY' + this.relay);
         }
@@ -37,6 +37,7 @@
             <option value="5">K5</option>
             <option value="6">K6</option>
             <option value="7">K7</option>
+            <option value="8">K8</option>
         </select>
     </div>
 </script>

--- a/relay.js
+++ b/relay.js
@@ -8,7 +8,7 @@ module.exports = function (RED) {
         var node = this;
         node.on('input', function (msg) {
             let type = RED.nodes.getNode(config.config_plate).model;
-            let relayValid = (type == "RELAYplate" || type == "TINKERplate" && node.relay < 3);
+            let relayValid = (type == "RELAYplate2" || type == "RELAYplate" && node.relay < 8 || type == "TINKERplate" && node.relay < 3);
 
             let validInputs = ["on", "off", "toggle"];
             let inputValid = (typeof msg.payload === 'string' && validInputs.includes(msg.payload));


### PR DESCRIPTION
1) Removed references to MOTORplate in the README file since it is unused for now
2) Added support for the upcoming RELAYplate2 to the RELAY node
3) Created the PWM node which has been tested to work on the DAQC, DAQC2, and TINKERplate.